### PR TITLE
SI-10631 Use mongosh instead of MongoDB; upgrade Ubuntu to jammy-20231211.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 # Base tools & JRE
 RUN apt-get update && \
-  apt-get install -y curl wget default-jre gnupg lsb-release
+  apt-get install -y curl wget default-jre gnupg lsb-release jq ripgrep moreutils
 
 # Install Node
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get install -y nodejs
 RUN node --version && npm --version
 
 # Install MongoDB
-RUN apt-get install libcurl4 libgssapi-krb5-2 libldap-2.5-0 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
+RUN apt-get install -y libcurl4 libgssapi-krb5-2 libldap-2.5-0 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
 ENV MONGO_VERSION="6.0.12" 
 ENV PLATFORM="ubuntu2204"
 ENV MONGO_DIR="mongodb-linux-x86_64-${PLATFORM}-${MONGO_VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy-20231004
+FROM ubuntu:jammy-20231211.1
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
@@ -12,9 +12,9 @@ RUN apt-get install -y nodejs
 RUN node --version && npm --version
 
 # Install MongoDB
-RUN apt-get install libcurl4 openssl liblzma5
-ENV MONGO_VERSION="6.0.11" 
-ENV PLATFORM="ubuntu1804"
+RUN apt-get install libcurl4 libgssapi-krb5-2 libldap-2.5-0 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
+ENV MONGO_VERSION="6.0.12" 
+ENV PLATFORM="ubuntu2204"
 ENV MONGO_DIR="mongodb-linux-x86_64-${PLATFORM}-${MONGO_VERSION}"
 ENV MONGO_TGZ="${MONGO_DIR}.tgz"
 RUN wget https://fastdl.mongodb.org/linux/${MONGO_TGZ} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,11 @@ RUN wget https://fastdl.mongodb.org/linux/${MONGO_TGZ} && \
   rm ${MONGO_TGZ} && \
   cp ${MONGO_DIR}/bin/* /usr/bin
 
+# Install mongosh
+ENV MONGOSH_DL_URL="https://downloads.mongodb.com/compass/mongodb-mongosh_2.1.1_amd64.deb"
+RUN curl -o ./mongosh.deb -L ${MONGOSH_DL_URL} && \
+  dpkg -i ./mongosh.deb && \
+  rm ./mongosh.deb
+
 # Remove apt cache
 RUN rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,17 +11,6 @@ RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN apt-get install -y nodejs
 RUN node --version && npm --version
 
-# Install MongoDB
-RUN apt-get install -y libcurl4 libgssapi-krb5-2 libldap-2.5-0 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
-ENV MONGO_VERSION="6.0.12" 
-ENV PLATFORM="ubuntu2204"
-ENV MONGO_DIR="mongodb-linux-x86_64-${PLATFORM}-${MONGO_VERSION}"
-ENV MONGO_TGZ="${MONGO_DIR}.tgz"
-RUN wget https://fastdl.mongodb.org/linux/${MONGO_TGZ} && \
-  tar -zxvf ${MONGO_TGZ} && \
-  rm ${MONGO_TGZ} && \
-  cp ${MONGO_DIR}/bin/* /usr/bin
-
 # Install mongosh
 ENV MONGOSH_DL_URL="https://downloads.mongodb.com/compass/mongodb-mongosh_2.1.1_amd64.deb"
 RUN curl -o ./mongosh.deb -L ${MONGOSH_DL_URL} && \


### PR DESCRIPTION
# Resolves [SI-10631](https://suitespot.atlassian.net/browse/SI-10631)

**Changes purposed in this Pull request:**
- Update `ubuntu` from `jammy-20231004` to `jammy-20231211.1`
- Remove MongoDB
- Install `mongosh`

[SI-10631]: https://suitespot.atlassian.net/browse/SI-10631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ